### PR TITLE
Legacy + Scary Items options

### DIFF
--- a/BloodwebGenerator.cs
+++ b/BloodwebGenerator.cs
@@ -15,7 +15,8 @@
                 {
                     if (!Extras.AddNonInventoryItems && !inventoryItem.ShouldBeInInventory) continue;
                     if (!Extras.AddEventItems && inventoryItem.EventId != "None") continue;
-                    
+                    if (!Extras.AddScaryItems && Extras.IsScaryItem(inventoryItem.ItemId)) continue;
+
                     BloodwebList.Add(new Classes.InventoryItemBloodweb
                     {
                         ItemId = inventoryItem.ItemId,
@@ -30,6 +31,7 @@
                     if (characterType.Contains("Slasher") && (addon.CharacterDefaultItem != characterPower)) continue;
                     if (!Extras.AddNonInventoryItems && !addon.ShouldBeInInventory) continue;
                     if (!Extras.AddEventItems && addon.EventId != "None") continue;
+                    if (!Extras.AddScaryItems && Extras.IsScaryItem(addon.ItemId)) continue;
 
                     BloodwebList.Add(new Classes.InventoryItemBloodweb
                     {
@@ -45,7 +47,8 @@
                     if (!Extras.AddNonInventoryItems && !offering.ShouldBeInInventory) continue;
                     if (!Extras.AddEventItems && offering.EventId != "None") continue;
                     if (!Extras.AddRetiredOfferings && offering.Availability == "EItemAvailability::Retired") continue;
-                    
+                    if (!Extras.AddScaryItems && Extras.IsScaryItem(offering.ItemId)) continue;
+
                     BloodwebList.Add(new Classes.InventoryItemBloodweb
                     {
                         ItemId = offering.ItemId,
@@ -58,7 +61,8 @@
             {
                 if (!Extras.AddNonInventoryItems && !item.ShouldBeInInventory) continue;
                 if (!Extras.AddEventItems && item.EventId != "None") continue;
-                
+                if (!Extras.AddScaryItems && Extras.IsScaryItem(item.ItemId)) continue;
+
                 TivoTigs.Add(new Classes.ItemBloodweb
                 {
                     ItemId = item.ItemId,
@@ -70,7 +74,8 @@
             {
                 if (!Extras.AddNonInventoryItems && !item.ShouldBeInInventory) continue;
                 if (!Extras.AddEventItems && item.EventId != "None") continue;
-                
+                if (!Extras.AddScaryItems && Extras.IsScaryItem(item.ItemId)) continue;
+
                 TivoTigs.Add(new Classes.ItemBloodweb
                 {
                     ItemId = item.ItemId,
@@ -83,7 +88,8 @@
                 if (!Extras.AddNonInventoryItems && !item.ShouldBeInInventory) continue;
                 if (!Extras.AddEventItems && item.EventId != "None") continue;
                 if (!Extras.AddRetiredOfferings && item.Availability == "EItemAvailability::Retired") continue;
-                
+                if (!Extras.AddScaryItems && Extras.IsScaryItem(item.ItemId)) continue;
+
                 TivoTigs.Add(new Classes.ItemBloodweb
                 {
                     ItemId = item.ItemId,

--- a/Cdn.cs
+++ b/Cdn.cs
@@ -18,6 +18,7 @@
 
             Console.WriteLine("Generating CDN files...");
 
+            Console.WriteLine("Generating Catalog file...");
             (string, bool) catalog = await SendRequest("https://essenceuwu.uk/api/v1/DeadByDaylight/CDN/catalog", "Catalog");
             if(catalog.Item2)
             {
@@ -29,6 +30,7 @@
                 Console.WriteLine(catalog.Item1);
             }
 
+            Console.WriteLine("Generating Killswitch file...");
             (string, bool) killswitch = await SendRequest("https://essenceuwu.uk/api/v1/DeadByDaylight/CDN/killswitch", "Killswitch");
             if(killswitch.Item2)
             {
@@ -71,11 +73,11 @@
             {
                 if (ex.CancellationToken.IsCancellationRequested)
                 {
-                    return ($"The request to get {file} file failed due to manual cancellation.", false);
+                    return ($"The request to get {file} file failed due to timeout.", false);
                 }
                 else
                 {
-                    return ($"The request to get {file} file failed due to timeout.", false);
+                    return ($"The request to get {file} file failed due to an error. (${ex.Message})", false);
                 }
             }
         }

--- a/Extras.cs
+++ b/Extras.cs
@@ -11,9 +11,64 @@ namespace Melancholy
         public static bool AddRetiredOfferings { get; set; } = false;
         public static bool AddEventItems { get; set; } = true;
         public static bool AddBannersBadges { get; set; } = true;
+        public static bool AddScaryItems { get; set; } = false;
+        public static bool AddLegacy { get; set; } = true;
 
         private static int Padding(string output) => (Console.WindowWidth / 2) - (output.Length / 2);
         private static void CenterText(string text) => Console.WriteLine("{0}{1}", new string(' ', Padding(text)), text);
+
+        private static List<string> ScaryItems = new List<string>() 
+        {
+            "TN_Head01_Smile",
+            "DF_Torso04_AdmBahroo",
+            "DF_Torso04_PandaTVChampKraken",
+            "D_Torso02_CartoonZ",
+            "DF_Torso04_BloodLetting",
+            "DF_Torso04_TwitchKraken",
+            "DF_Torso04_KingKongKraken",
+            "M_Torso02_Bryce",
+            "M_Torso03_AngryPug",
+            "MT_Torso04_TwitchKraken",
+            "MT_Torso04_KingKongKraken",
+            "CM_Torso02_Sxyhxy",
+            "CM_Torso03_72hrs",
+            "NK_Torso01_Crew01Kraken"
+        };
+
+        private static List<string> LegacyCosmetics = new List<string>()
+        {
+            "CM_Head01_LP01",
+            "CM_Legs01_LP01",
+            "CM_Torso01_LP01",
+            "DF_Head01_LP01",
+            "DF_Legs01_LP01",
+            "DF_Torso01_LP01",
+            "HB_Hammer01_LP01",
+            "HB_Legs01_LP01",
+            "HB_Torso01_LP01",
+            "JP_Head01_LP01",
+            "JP_Legs01_LP01",
+            "JP_Torso01_LP01",
+            "MT_Head01_LP01",
+            "MT_Legs01_LP01",
+            "MT_Torso01_LP01",
+            "NK_Head01_LP01",
+            "NK_Legs01_LP01",
+            "NK_Torso01_LP01",
+            "NR_Body01_LP01",
+            "NR_BoneSaw01_LP01",
+            "NR_Head01_LP01",
+            "TR_Body01_LP01",
+            "TR_Head01_LP01",
+            "TR_Machete01_LP01",
+            "WR_Body01_LP01",
+            "WR_Head01_LP01",
+            "WR_Machete02_LP01",
+        };
+
+        public static bool IsScaryItem(string item) => ScaryItems.Contains(item);
+        public static bool IsLegacyCosmetic(string cosmetic) => LegacyCosmetics.Contains(cosmetic);
+
 
         public static void Header()
         {

--- a/GetAll.cs
+++ b/GetAll.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using CUE4Parse.GameTypes.PUBG.Assets.Exports;
+using Newtonsoft.Json;
 
 namespace Melancholy
 {
@@ -33,6 +34,7 @@ namespace Melancholy
                         if (character.CharacterType == item.CharacterType) includeItem = true;
                         if (!Extras.AddNonInventoryItems && !item.ShouldBeInInventory) includeItem = false;
                         if (!Extras.AddEventItems && item.EventId != "None") includeItem = false;
+                        if (!Extras.AddScaryItems && Extras.IsScaryItem(item.ItemId)) includeItem = false;
 
                         return includeItem;
                     })
@@ -54,6 +56,7 @@ namespace Melancholy
                             character.CharacterDefaultItem != addon.CharacterDefaultItem) includeAddon = false;
                         if (!Extras.AddNonInventoryItems && !addon.ShouldBeInInventory) includeAddon = false;
                         if (!Extras.AddEventItems && addon.EventId != "None") includeAddon = false;
+                        if (!Extras.AddScaryItems && Extras.IsScaryItem(addon.ItemId)) includeAddon = false;
 
                         return includeAddon;
                     })
@@ -75,6 +78,7 @@ namespace Melancholy
                         if (!Extras.AddEventItems && offering.EventId != "None") includeOffering = false;
                         if (!Extras.AddRetiredOfferings && offering.Availability == "EItemAvailability::Retired")
                             includeOffering = false;
+                        if (!Extras.AddScaryItems && Extras.IsScaryItem(offering.ItemId)) includeOffering = false;
 
                         return includeOffering;
                     })

--- a/Market.cs
+++ b/Market.cs
@@ -79,6 +79,7 @@ namespace Melancholy
                     {
                         if (!Extras.AddNonInventoryItems && !itemAddon.ShouldBeInInventory) includeItem = false;
                         if (!Extras.AddEventItems && itemAddon.EventId != "None") includeItem = false;
+                        if(!Extras.AddScaryItems && Extras.IsScaryItem(itemAddon.ItemId)) includeItem = false;
                     }
                     else if (item is Classes.ItemOfferingPerk itemOfferingPerk)
                     {
@@ -86,11 +87,13 @@ namespace Melancholy
                             itemOfferingPerk.Availability == "EItemAvailability::Retired") includeItem = false;
                         if (!Extras.AddNonInventoryItems && !itemOfferingPerk.ShouldBeInInventory) includeItem = false;
                         if (!Extras.AddEventItems && itemOfferingPerk.EventId != "None") includeItem = false;
+                        if (!Extras.AddScaryItems && Extras.IsScaryItem(itemOfferingPerk.ItemId)) includeItem = false;
                     } 
                     else if(item is Classes.Customization customizationItem)
                     {
-                        // Remove if category is either ECustomizationCategory::Banner or ECustomizationCategory::Badge
                         if (!Extras.AddBannersBadges && (customizationItem.Category == "ECustomizationCategory::Badge" || customizationItem.Category == "ECustomizationCategory::Banner")) includeItem = false;
+                        if (!Extras.AddScaryItems && Extras.IsScaryItem(customizationItem.CosmeticId)) includeItem = false;
+                        if (!Extras.AddLegacy && Extras.IsLegacyCosmetic(customizationItem.CosmeticId)) includeItem = false;
                     }
 
                     return includeItem;

--- a/Program.cs
+++ b/Program.cs
@@ -96,7 +96,13 @@ SkipSettings:
    
     string ShouldHaveBannersBadges = Extras.PromptOptionInput("Should banners and badges be included? (Y/n): ");
     Extras.AddBannersBadges = ShouldHaveBannersBadges is not ("no" or "n");
-    
+
+    string ShouldHaveLegacy = Extras.PromptOptionInput("Should legacy (pre 2016) prestige clothing be added? (Y/n): ");
+    Extras.AddLegacy = ShouldHaveLegacy is not ("no" or "n");
+
+    string ShouldHaveScaryItems = Extras.PromptOptionInput("Should \"scary\" things be included (like dev only items etc.)? (y/N): ");
+    Extras.AddScaryItems = ShouldHaveScaryItems is ("yes" or "y");
+
     Console.Clear();
     Extras.Header();
 


### PR DESCRIPTION
Ability to choose to not get Legacy Skins and also not "Scary" Cosmetics, that are completely exclusive.

Missing dev bnr and bdg, will find them later and add, can just be added to the ScaryItems List in Extras

Also fixed incorrect error message in CDN and also now showing which file its trying to generate, so if it times out, you can see it begins to generate killswitch, before it looked like the program has just died.